### PR TITLE
big Stack refactoring

### DIFF
--- a/bang.game.php
+++ b/bang.game.php
@@ -134,7 +134,6 @@ class bang extends Table
     if (!$player->isEliminated()) {
       $this->stEliminate();
     }
-    Stack::nextState();
     //      throw new BgaVisibleSystemException(
     //        'Zombie player ' . $activePlayer . ' stuck in unexpected state ' . $state['name']
     //      );

--- a/modules/php/Cards/Bang.php
+++ b/modules/php/Cards/Bang.php
@@ -44,9 +44,11 @@ class Bang extends \BANG\Models\BrownCard
   {
     if ($card->getType() != CARD_BARREL) {
       // Barrel knows how to handle this
-      $atom = Stack::top();
-      $atom['missedNeeded'] = $atom['missedNeeded'] - 1;
-      Stack::insertAfter($atom);
+      $missedNeeded = Stack::top()['missedNeeded'] - 1;
+      if ($missedNeeded > 0) {
+        Stack::suspendCtx();
+      }
+      Stack::updateAttackAtomAfterAction($missedNeeded, $card->getType());
     }
     parent::react($card, $player);
   }

--- a/modules/php/Cards/Barrel.php
+++ b/modules/php/Cards/Barrel.php
@@ -29,28 +29,21 @@ class Barrel extends \BANG\Models\BlueCard
   public function activate($player, $args = [])
   {
     Notifications::useCard($player, $this);
+    Stack::suspendCtx();
     $player->addFlipAtom($this);
-    Stack::resolve();
   }
 
-  public function resolveFlipped($card, $player, $switchToNextState = null)
+  public function resolveFlipped($card, $player)
   {
     $missedNeeded = Stack::top()['missedNeeded'] ?? 1;
-    Stack::shift();
 
-    $success = false;
     // Draw an heart => success
     if ($card->getCopyColor() == 'H') {
       Notifications::tell(clienttranslate('Barrel was successful'));
-      $success = true;
       $missedNeeded -= 1;
     } else {
       Notifications::tell(clienttranslate('Barrel failed'));
     }
-    $newAtom = Utils::updateAtomAfterAction(Stack::top(), $missedNeeded, $this->type, $success && $switchToNextState);
-    Stack::insertAfter($newAtom);
-    if ($switchToNextState) {
-      Stack::nextState();
-    }
+    Stack::updateAttackAtomAfterAction($missedNeeded, $this->type);
   }
 }

--- a/modules/php/Cards/Duel.php
+++ b/modules/php/Cards/Duel.php
@@ -40,8 +40,7 @@ class Duel extends \BANG\Models\BrownCard
   public function play($player, $args)
   {
     parent::play($player, $args);
-    $atom = [
-      'state' => ST_REACT,
+    $atom = Stack::newAtom(ST_REACT, [
       'type' => 'duel',
       'msgActive' => clienttranslate('${you} may react to the duel by discarding a Bang!'),
       'msgInactive' => clienttranslate('${actplayer} may react to the duel by discarding a Bang!'),
@@ -49,7 +48,7 @@ class Duel extends \BANG\Models\BrownCard
       'attacker' => $player->getId(),
       'opponent' => $args['player'],
       'pId' => $args['player'],
-    ];
+    ]);
 
     Stack::insertOnTop($atom);
   }

--- a/modules/php/Cards/Dynamite.php
+++ b/modules/php/Cards/Dynamite.php
@@ -46,7 +46,6 @@ class Dynamite extends \BANG\Models\BlueCard
       Cards::equip($this->id, $next->getId());
       Notifications::moveCard($this, $player, $next);
     }
-    Stack::nextState();
   }
 
   public function play($player, $args)

--- a/modules/php/Cards/Jail.php
+++ b/modules/php/Cards/Jail.php
@@ -58,7 +58,6 @@ class Jail extends \BANG\Models\BlueCard
 
     if ($card->getCopyColor() == 'H') {
       Notifications::tell('${player_name} can make his turn', $args);
-      Stack::nextState();
     } else {
       Notifications::tell('${player_name} is skipped', $args);
       Stack::clearAllLeaveLast();

--- a/modules/php/Characters/BartCassidy.php
+++ b/modules/php/Characters/BartCassidy.php
@@ -16,11 +16,10 @@ class BartCassidy extends \BANG\Models\Player
   public function loseLife($amount = 1)
   {
     parent::loseLife($amount);
-    Stack::insertAfterCardResolution([
+    Stack::insertAfterCardResolution(Stack::newAtom(ST_TRIGGER_ABILITY, [
       'pId' => $this->id,
-      'state' => ST_TRIGGER_ABILITY,
       'amount' => $amount,
-    ]);
+    ]));
   }
 
   public function useAbility($ctx)

--- a/modules/php/Characters/ElGringo.php
+++ b/modules/php/Characters/ElGringo.php
@@ -27,11 +27,10 @@ class ElGringo extends \BANG\Models\Player
 
     $attacker = Players::getCurrentTurn();
     if ($attacker->getId() != $this->id) {
-      Stack::insertAfterCardResolution([
+      Stack::insertAfterCardResolution(Stack::newAtom(ST_TRIGGER_ABILITY, [
         'pId' => $this->id,
-        'state' => ST_TRIGGER_ABILITY,
         'amount' => $amount,
-      ]);
+      ]));
     }
   }
 

--- a/modules/php/Characters/JesseJones.php
+++ b/modules/php/Characters/JesseJones.php
@@ -24,10 +24,9 @@ class JesseJones extends \BANG\Models\Player
   public function drawCardsPhaseOne()
   {
     // TODO : auto skip if argDrawCard only has 'deck' inside
-    Stack::insertOnTop([
-      'state' => ST_ACTIVE_DRAW_CARD,
+    Stack::insertOnTop(Stack::newAtom(ST_ACTIVE_DRAW_CARD, [
       'pId' => $this->id,
-    ]);
+    ]));
   }
 
   public function argDrawCard()

--- a/modules/php/Characters/Jourdonnais.php
+++ b/modules/php/Characters/Jourdonnais.php
@@ -35,8 +35,8 @@ class Jourdonnais extends \BANG\Models\Player
   public function useAbility()
   {
     Cards::drawForLocation(LOCATION_FLIPPED, 1);
+    Stack::suspendCtx();
     $this->addResolveFlippedAtom($this);
-    Stack::resolve();
   }
 
   public function resolveFlipped($card)
@@ -44,7 +44,6 @@ class Jourdonnais extends \BANG\Models\Player
     Notifications::flipCard($this, $card, $this);
     $missedNeeded = Stack::top()['missedNeeded'] ?? 1;
 
-    Stack::shift();
     if ($card->getCopyColor() == 'H') {
       Notifications::tell(clienttranslate('Jourdonnais effect was successful'));
 
@@ -52,8 +51,7 @@ class Jourdonnais extends \BANG\Models\Player
     } else {
       Notifications::tell(clienttranslate('Jourdonnais effect failed'));
     }
-    $newAtom = Utils::updateAtomAfterAction(Stack::top(), $missedNeeded, $this->character);
-    Stack::insertAfter($newAtom);
-    $this->handleMultipleMissed(true);
+    Stack::updateAttackAtomAfterAction($missedNeeded, $this->character);
+    $this->notifyAboutAnotherMissed();
   }
 }

--- a/modules/php/Characters/LuckyDuke.php
+++ b/modules/php/Characters/LuckyDuke.php
@@ -31,7 +31,7 @@ class LuckyDuke extends \BANG\Models\Player
     }
 
     Log::addAction('selection', ['players' => [$this->id], 'src' => $src->getName()]);
-    parent::addResolveFlippedAtom($src, true);
+    parent::addResolveFlippedAtom($src);
     $this->prepareSelection($src, [$this->getId()], true, 1, true);
   }
 

--- a/modules/php/Characters/PedroRamirez.php
+++ b/modules/php/Characters/PedroRamirez.php
@@ -25,17 +25,15 @@ class PedroRamirez extends \BANG\Models\Player
     if (is_null(Cards::getLastDiscarded())) {
       parent::drawCardsPhaseOne();
     } else {
-      Stack::insertOnTop([
-        'state' => ST_ACTIVE_DRAW_CARD,
+      Stack::insertOnTop(Stack::newAtom(ST_ACTIVE_DRAW_CARD, [
         'pId' => $this->id,
-      ]);
+      ]));
     }
   }
 
   public function argDrawCard()
   {
     $options = [LOCATION_DECK, LOCATION_DISCARD];
-
     return ['options' => $options];
   }
 

--- a/modules/php/Characters/SidKetchum.php
+++ b/modules/php/Characters/SidKetchum.php
@@ -47,13 +47,5 @@ class SidKetchum extends \BANG\Models\Player
     }
     Notifications::discardedCards($this, $cards);
     $this->gainLife();
-
-    // If we were in the end of life state and now have enough life point, proceed to next state
-    if (Stack::top()['state'] == ST_REACT_BEER && $this->hp > 0) {
-      Stack::nextState();
-    } else {
-      // Otherwise loop back in same state
-      Stack::resolve();
-    }
   }
 }

--- a/modules/php/Characters/SuzyLafayette.php
+++ b/modules/php/Characters/SuzyLafayette.php
@@ -17,10 +17,9 @@ class SuzyLafayette extends \BANG\Models\Player
   {
     if ($this->getHand()->count() == 0) {
       Stack::insertAfterCardResolution(
-        [
+        Stack::newAtom(ST_TRIGGER_ABILITY, [
           'pId' => $this->id,
-          'state' => ST_TRIGGER_ABILITY,
-        ],
+        ]),
         false
       );
     }

--- a/modules/php/Core/Globals.php
+++ b/modules/php/Core/Globals.php
@@ -112,6 +112,6 @@ class Globals extends \BANG\Helpers\DB_Manager
 
   public static function enabledStackLogger()
   {
-    return true;
+    return false;
   }
 }

--- a/modules/php/Core/Globals.php
+++ b/modules/php/Core/Globals.php
@@ -75,7 +75,7 @@ class Globals extends \BANG\Helpers\DB_Manager
       // Sanity check : does the name correspond to a declared variable ?
       $name = strtolower($match[2]) . $match[3];
       if (!\array_key_exists($name, self::$variables)) {
-        throw new InvalidArgumentException("Property {$name} doesn't exist");
+        throw new \InvalidArgumentException("Property {$name} doesn't exist");
       }
 
       // Create in DB if don't exist yet
@@ -99,7 +99,7 @@ class Globals extends \BANG\Helpers\DB_Manager
         return $value;
       } elseif ($match[1] == 'inc') {
         if (self::$variables[$name] != 'int') {
-          throw new InvalidArgumentException("Trying to increase {$name} which is not an int");
+          throw new \InvalidArgumentException("Trying to increase {$name} which is not an int");
         }
 
         $getter = 'get' . $match[2] . $match[3];
@@ -112,6 +112,6 @@ class Globals extends \BANG\Helpers\DB_Manager
 
   public static function enabledStackLogger()
   {
-    return false;
+    return true;
   }
 }

--- a/modules/php/Core/Stack.php
+++ b/modules/php/Core/Stack.php
@@ -15,45 +15,43 @@ class Stack
 
   public static function setup($flow)
   {
-    $stack = [];
-    foreach ($flow as $atom) {
-      if (is_int($atom)) {
-        $stack[] = [
-          'state' => $atom,
-          'pId' => ($atom == ST_END_OF_TURN || $atom == ST_GAME_END) ? null : Globals::getPIdTurn(),
+    $ctx = Stack::getCtx();
+    if (empty($ctx)) { // Ok, that should be the very game start
+      $firstAtom = Stack::newAtom(ST_START_OF_TURN, []);
+      Stack::setCtx($firstAtom);
+      $stack = [$firstAtom];
+    } else {
+      $stack = [$ctx];
+    }
+
+    foreach ($flow as $state) {
+      if (is_int($state)) {
+        $options = [
+          'pId' => ($state == ST_END_OF_TURN || $state == ST_GAME_END) ? null : Globals::getPIdTurn(),
         ];
+        if ($state == ST_PLAY_CARD) {
+          $options['suspended'] = true;
+        }
+        $stack[] = Stack::newAtom($state, $options);
       }
     }
-    Globals::setStack($stack);
+    Stack::set($stack);
+    Stack::setCtx($stack[0]);
   }
 
-  public function top()
+  public static function top()
   {
-    $stack = Globals::getStack();
+    $stack = Stack::get();
     return reset($stack);
   }
 
-  public function getNextState()
+  public static function getNextState()
   {
-    $stack = Globals::getStack();
+    $stack = Stack::get();
     return $stack[1] ?? null;
   }
 
-  public function shift()
-  {
-    $stack = Globals::getStack();
-    $elem = array_shift($stack);
-    Globals::setStack($stack);
-    if (Globals::enabledStackLogger()) {
-      var_dump("[Stack logger] Shifted current element out of Stack:");
-      var_dump($elem);
-      var_dump("[Stack logger] After shift Stack looks like this:");
-      var_dump(Globals::getStack());
-    }
-    return $elem;
-  }
-
-  public function resolve()
+  private static function resolve()
   {
     if (Globals::getGameIsOver()) {
       return;
@@ -68,7 +66,7 @@ class Stack
       throw new \feException('Stack engine is empty !');
     }
 
-    Globals::setStackCtx($atom);
+    Stack::setCtx($atom);
 
     $pId = self::getGame()->getActivePlayerId();
     // Jump to resolveStack state to ensure we can change active pId
@@ -80,40 +78,32 @@ class Stack
     self::getGame()->gamestate->jumpToState($atom['state']);
   }
 
-  public function nextState()
+  // TODO: Try to merge with insertAfter(). After Stack refactoring they might not differ
+  public static function insertOnTop($atom)
   {
-    if (Globals::enabledStackLogger()) {
-      var_dump("[Stack logger] nextState is called");
-    }
-    self::shift();
-    self::resolve();
-  }
-
-  public function insertOnTop($atom)
-  {
-    $stack = Globals::getStack();
+    $stack = Stack::get();
     array_unshift($stack, $atom);
-    Globals::setStack($stack);
+    Stack::set($stack);
     if (Globals::enabledStackLogger()) {
       var_dump("[Stack logger] Inserted a new atom on top and now Stack looks like this:");
-      var_dump(Globals::getStack());
+      var_dump(Stack::get());
     }
     return $atom;
   }
 
-  public function insertAfter($atom, $pos = 1)
+  public static function insertAfter($atom, $pos = 1)
   {
-    $stack = Globals::getStack();
+    $stack = Stack::get();
     array_splice($stack, $pos, 0, [$atom]);
-    Globals::setStack($stack);
+    Stack::set($stack);
     if (Globals::enabledStackLogger()) {
       var_dump("[Stack logger] Inserted a new atom at position {$pos} and now Stack looks like this:");
-      var_dump(Globals::getStack());
+      var_dump(Stack::get());
     }
     return $atom;
   }
 
-  public function insertAfterCardResolution($atom, $raiseException = true)
+  public static function insertAfterCardResolution($atom, $raiseException = true)
   {
     if (Globals::enabledStackLogger()) {
       var_dump("[Stack logger] insertAfterCardResolution is called");
@@ -130,7 +120,7 @@ class Stack
     }
 
     $cId = $top['src']['id'];
-    $stack = Globals::getStack();
+    $stack = Stack::get();
     for ($i = 1; $i < count($stack); $i++) {
       if (!isset($stack[$i]['src']) || $stack[$i]['src']['id'] != $cId) {
         break;
@@ -141,23 +131,166 @@ class Stack
 
   public function isItLastElimination()
   {
-    $stack = Globals::getStack();
-    return count($stack) == 0 || $stack[0]['state'] != ST_ELIMINATE;
+    $stack = Stack::get();
+    return count($stack) == 0 || $stack[1]['state'] != ST_ELIMINATE;
   }
 
-  public function clearAllLeaveLast()
+  public static function clearAllLeaveLast()
   {
-    $stack = Globals::getStack();
-    Globals::setStack([end($stack)]);
+    $stack = Stack::get();
+    Stack::set([Stack::getCtx(), end($stack)]);
+  }
+
+  public static function removePlayerAtoms($pId)
+  {
+    $stack = Stack::get();
+    Utils::filter($stack, function ($atom) use ($pId) {
+      return !isset($atom['pId']) || $atom['pId'] != $pId || $atom['uid'] == Stack::getCtx()['uid'];
+    });
+    Stack::set($stack);
+  }
+
+  private static function get() {
+    return Globals::getStack();
+  }
+
+  private static function set($stack) {
+    Globals::setStack($stack);
+  }
+
+  public static function getCtx() {
+    return Globals::getStackCtx();
+  }
+
+  private static function setCtx($ctx) {
+    Globals::setStackCtx($ctx);
+  }
+
+  public static function newAtom($state, $atom) {
+    $atom['state'] = $state;
+    $atom = ['uid' => uniqid()] + $atom;
+    return $atom;
+  }
+
+  public static function finishState() {
+    var_dump('finishState() started');
+    $ctx = Stack::getCtx();
+    if (!Stack::isSuspended($ctx)) {
+      $ctxIndex = Stack::getAtomIndexByUid($ctx['uid']);
+      $currentStack = Stack::get();
+      if (Globals::enabledStackLogger()) {
+        var_dump('CTX:');
+        var_dump($ctx);
+        var_dump('INDEX:');
+        var_dump($ctxIndex);
+      }
+      array_splice($currentStack, $ctxIndex, 1);
+      if (Globals::enabledStackLogger()) {
+        var_dump('NEW STACK:');
+        var_dump($currentStack);
+      }
+      Stack::set($currentStack);
+    }
+    if (Globals::enabledStackLogger()) {
+      var_dump('FINISHED WITH FINISHING!');
+    }
     Stack::resolve();
   }
 
-  public function removePlayerNodes($pId)
+  private static function isSuspended($atom) {
+    return isset($atom['suspended']) && $atom['suspended'];
+  }
+
+  public static function suspendCtx() {
+    $ctx = Stack::getCtx();
+    if (!Stack::isSuspended($ctx)) {
+      if (Globals::enabledStackLogger()) {
+        var_dump('Ctx isSuspended is');
+        var_dump(Stack::isSuspended($ctx));
+        var_dump('BEFORE stack is');
+        var_dump(Stack::get());
+      }
+
+      $stack = Stack::get();
+      $ctxIndex = Stack::getAtomIndexByUid($ctx['uid']);
+      $atom = array_splice($stack, $ctxIndex, 1);
+      $atom[0]['suspended'] = true;
+      array_splice($stack, $ctxIndex, 0, $atom);
+      Stack::set($stack);
+      Stack::setCtx($stack[$ctxIndex]);
+
+      if (Globals::enabledStackLogger()) {
+        var_dump('AFTER stack is');
+        var_dump(Stack::get());
+      }
+    }
+  }
+
+  public static function unsuspendNext($state = null) {
+    if ($state == null) {
+      $atomIndex = Stack::getFirstSuspendedAtomIndex();
+    } else {
+      $atomIndex = Stack::getFirstAtomIndexByState($state);
+    }
+    $stack = Stack::get();
+    // TODO: Convert atom to object to avoid this splicing
+    if (Stack::isSuspended($stack[$atomIndex])) {
+      $atom = array_splice($stack, $atomIndex, 1);
+      unset($atom[0]['suspended']);
+      array_splice($stack, $atomIndex, 0, $atom);
+      Stack::set($stack);
+    }
+
+    if ($stack[$atomIndex]['uid'] == Stack::getCtx()['uid']) {
+      Stack::setCtx($stack[$atomIndex]);
+    }
+  }
+
+  private static function getAtomIndexByUid($uid) {
+    return Stack::findBy('uid', $uid);
+  }
+
+  private static function getFirstAtomIndexByState($state) {
+    return Stack::findBy('state', $state);
+  }
+
+  private static function getFirstSuspendedAtomIndex() {
+    return Stack::findBy('suspended', true);
+  }
+
+  private static function findBy($option, $value) {
+    $ctxIndex = -1;
+    $stack = Stack::get();
+    foreach ($stack as $key => $atom) {
+      if (isset($atom[$option]) && $atom[$option] == $value) {
+        $ctxIndex = $key;
+        break;
+      }
+    }
+    if ($ctxIndex == -1) {
+      debug_print_backtrace();
+      throw new \BgaVisibleSystemException('Class Stack: ctxIndex == -1. Please report this to BGA bug tracker');
+    }
+    return $ctxIndex;
+  }
+
+  public static function updateAttackAtomAfterAction($missedNeeded, $abilityOrCardUsed)
   {
-    $stack = Globals::getStack();
-    Utils::filter($stack, function ($atom) use ($pId) {
-      return !isset($atom['pId']) || $atom['pId'] != $pId;
-    });
-    Globals::setStack($stack);
+    $stack = Stack::get();
+    $atomIndex = Stack::getFirstAtomIndexByState(ST_REACT);
+    if ($missedNeeded == 0) {
+      Stack::unsuspendNext(ST_REACT);
+      if (Stack::getCtx()['state'] != ST_REACT) {
+        array_splice($stack, $atomIndex, 1);
+      }
+    } else {
+      $atom = array_splice($stack, $atomIndex, 1)[0];
+      $atom['missedNeeded'] = $missedNeeded;
+      $used = $atom['used'] ?? [];
+      array_push($used, $abilityOrCardUsed);
+      $atom['used'] = $used;
+      array_splice($stack, $atomIndex, 0, [$atom]);
+    }
+    Stack::set($stack);
   }
 }

--- a/modules/php/Core/Stack.php
+++ b/modules/php/Core/Stack.php
@@ -173,7 +173,6 @@ class Stack
   }
 
   public static function finishState() {
-    var_dump('finishState() started');
     $ctx = Stack::getCtx();
     if (!Stack::isSuspended($ctx)) {
       $ctxIndex = Stack::getAtomIndexByUid($ctx['uid']);

--- a/modules/php/Helpers/Utils.php
+++ b/modules/php/Helpers/Utils.php
@@ -41,16 +41,4 @@ abstract class Utils
   {
     return substr($copy, -1);
   }
-
-  public static function updateAtomAfterAction($atom, $missedNeeded, $abilityOrCardUsed, $switchToNextState = null)
-  {
-    $atom['missedNeeded'] = $missedNeeded;
-    $used = $atom['used'] ?? [];
-    array_push($used, $abilityOrCardUsed);
-    $atom['used'] = $used;
-    if ($switchToNextState) {
-      $atom['switchToNextState'] = $switchToNextState;
-    }
-    return $atom;
-  }
 }

--- a/modules/php/Models/AbstractCard.php
+++ b/modules/php/Models/AbstractCard.php
@@ -1,6 +1,6 @@
 <?php
 namespace BANG\Models;
-use BANG\Managers\Players;
+use BANG\Core\Stack;
 use BANG\Managers\Cards;
 use BANG\Core\Notifications;
 
@@ -206,6 +206,7 @@ class AbstractCard implements \JsonSerializable
   public function pass($player)
   {
     if ($this->effect['type'] == BASIC_ATTACK) {
+      Stack::unsuspendNext(ST_REACT);
       $player->loseLife();
     }
   }

--- a/modules/php/States/DrawCardsTrait.php
+++ b/modules/php/States/DrawCardsTrait.php
@@ -11,10 +11,9 @@ trait DrawCardsTrait
    */
   public function stDrawCards()
   {
-    Stack::shift();
     $player = Players::getActive();
     $player->drawCardsPhaseOne();
-    Stack::resolve();
+    Stack::finishState();
   }
 
   /************************
@@ -33,8 +32,7 @@ trait DrawCardsTrait
 
   public function draw($selected)
   {
-    Stack::shift();
     Players::getActive()->useAbility(['selected' => $selected]);
-    Stack::resolve();
+    Stack::finishState();
   }
 }

--- a/modules/php/States/EndOfLifeTrait.php
+++ b/modules/php/States/EndOfLifeTrait.php
@@ -16,7 +16,7 @@ trait EndOfLifeTrait
    */
   public function argReactBeer()
   {
-    $ctx = Globals::getStackCtx();
+    $ctx = Stack::getCtx();
     $player = Players::getActive();
 
     $hand = $player->getHand();
@@ -43,19 +43,15 @@ trait EndOfLifeTrait
 
     // If it's not enough, add a ELIMINATE node
     if ($player->getHp() <= 0) {
-      $ctx = Globals::getStackCtx();
-      $atom = [
-        'state' => ST_ELIMINATE,
+      $ctx = Stack::getCtx();
+      $atom = Stack::newAtom(ST_ELIMINATE, [
         'type' => 'eliminate',
         'src' => $ctx['src'],
         'attacker' => $ctx['attacker'],
         'pId' => $player->getId(),
-      ];
+      ]);
       Stack::insertAfterCardResolution($atom);
     }
-
-    // Resolve current beer state
-    Stack::nextState();
   }
 
   /**
@@ -63,10 +59,9 @@ trait EndOfLifeTrait
    */
   public function stEliminate()
   {
-    Stack::shift();
-    $ctx = Globals::getStackCtx();
+    $ctx = Stack::getCtx();
     $player = Players::get($ctx['pId']);
     $player->eliminate();
-    Stack::resolve();
+    Stack::finishState();
   }
 }

--- a/modules/php/States/PlayCardTrait.php
+++ b/modules/php/States/PlayCardTrait.php
@@ -50,6 +50,6 @@ trait PlayCardTrait
 
     // TODO : not sure what this function was doing before
     //  Players::handleRemainingEffects();
-    Stack::resolve();
+    Stack::finishState();
   }
 }

--- a/modules/php/States/ReactTrait.php
+++ b/modules/php/States/ReactTrait.php
@@ -9,14 +9,6 @@ trait ReactTrait
 {
   public function stReact()
   {
-    $atom = Stack::top();
-    if (isset($atom['missedNeeded']) && $atom['missedNeeded'] == 0) {
-      if (isset($atom['switchToNextState']) && $atom['switchToNextState']) {
-        Stack::nextState();
-      } else {
-        return;
-      }
-    }
     $player = Players::getActive();
     $args = $this->gamestate->state()['args'];
     $options = $args['_private']['active'];
@@ -36,7 +28,7 @@ trait ReactTrait
 
   public function argReact()
   {
-    $ctx = Globals::getStackCtx();
+    $ctx = Stack::getCtx();
     $player = Players::getActive();
     if ($ctx['state'] == ST_REACT) {
       $card = Cards::get($ctx['src']['id']);
@@ -50,11 +42,11 @@ trait ReactTrait
 
   function reactAux($player, $ids)
   {
-    $ctx = Globals::getStackCtx();
-    $player->react($ids, $ctx);
-    if ($ctx['state'] == Stack::top()['state']) { // Dirty hack to support Lucky Duke situation. To be refactored
-      Stack::nextState();
-    }
+//    $ctx = Stack::getCtx();
+//    $player->react($ids);
+//    if ($ctx['state'] == Stack::top()['state']) { // Dirty hack to support Lucky Duke situation. To be refactored
+//      Stack::finishState();
+//    }
   }
 
   /*
@@ -89,8 +81,9 @@ else {
     if ($this->gamestate->state_id() == ST_REACT_BEER) {
       $this->actReactBeer($ids);
     } else {
-      $this->reactAux($player, $ids);
+      $player->react($ids);
     }
+    Stack::finishState();
   }
 
   /*
@@ -118,5 +111,6 @@ else {
   public function useAbility($args)
   {
     Players::getCurrent()->useAbility($args);
+    Stack::finishState();
   }
 }

--- a/modules/php/States/ResolveFlippedTrait.php
+++ b/modules/php/States/ResolveFlippedTrait.php
@@ -11,14 +11,11 @@ trait ResolveFlippedTrait
    */
   public function stFlipCard()
   {
-    var_dump('stFlipCard() started');
     $atom = Stack::top();
     $player = Players::get($atom['pId']);
     $src = Cards::get($atom['src']['id']);
     $player->flip($src);
-    var_dump('stFlipCard() gonna finish');
     Stack::finishState();
-    var_dump('stFlipCard() finished');
   }
 
   /*
@@ -26,7 +23,6 @@ trait ResolveFlippedTrait
    */
   public function stResolveFlipped()
   {
-    var_dump('stResolveFlipped() started');
     $startingAtom = Stack::top();
     $player = Players::get($startingAtom['pId']);
     $srcCard = $startingAtom['src']['id'] == $startingAtom['pId'] ? $player : Cards::get($startingAtom['src']['id']);
@@ -38,8 +34,6 @@ trait ResolveFlippedTrait
       throw new \BgaVisibleSystemException("There's {$flippedCards->count()} card in LOCATION_FLIPPED");
     }
     Cards::moveAllInLocation(LOCATION_FLIPPED, LOCATION_DISCARD);
-    var_dump('stResolveFlipped() gonna finish');
     Stack::finishState();
-    var_dump('stResolveFlipped() finished');
   }
 }

--- a/modules/php/States/ResolveFlippedTrait.php
+++ b/modules/php/States/ResolveFlippedTrait.php
@@ -11,36 +11,35 @@ trait ResolveFlippedTrait
    */
   public function stFlipCard()
   {
+    var_dump('stFlipCard() started');
     $atom = Stack::top();
     $player = Players::get($atom['pId']);
     $src = Cards::get($atom['src']['id']);
-    Stack::shift();
     $player->flip($src);
-    Stack::resolve();
+    var_dump('stFlipCard() gonna finish');
+    Stack::finishState();
+    var_dump('stFlipCard() finished');
   }
 
   /*
    * stResolveFlipped: called if Dynamite/Jail/Barrel required resolving
    */
-  // Unlike stFlipCard() here we rely on reactAux() method to do Stack::nextState() for us
-  // This is a terrible implementation as we need to control each atom inside this atom only
-  // TODO: We need to refactor Stack to be more smart and control its own changes
   public function stResolveFlipped()
   {
+    var_dump('stResolveFlipped() started');
     $startingAtom = Stack::top();
     $player = Players::get($startingAtom['pId']);
     $srcCard = $startingAtom['src']['id'] == $startingAtom['pId'] ? $player : Cards::get($startingAtom['src']['id']);
     $flippedCards = Cards::getInLocation(LOCATION_FLIPPED);
     if ($flippedCards->count() == 1) {
-      $srcCard->resolveFlipped($flippedCards->first(), $player, $startingAtom['switchToNextState'] ?? null);
+      $srcCard->resolveFlipped($flippedCards->first(), $player);
     } else {
       // Shouldn't ever happen. There should be just 1 card flipped
       throw new \BgaVisibleSystemException("There's {$flippedCards->count()} card in LOCATION_FLIPPED");
     }
     Cards::moveAllInLocation(LOCATION_FLIPPED, LOCATION_DISCARD);
-    $currentAtom = Stack::top(); // It might have changed after resolveFlipped
-    if (isset($currentAtom['switchToNextState']) && $currentAtom['switchToNextState']) {
-      Stack::nextState();
-    }
+    var_dump('stResolveFlipped() gonna finish');
+    Stack::finishState();
+    var_dump('stResolveFlipped() finished');
   }
 }

--- a/modules/php/States/SelectCardTrait.php
+++ b/modules/php/States/SelectCardTrait.php
@@ -48,7 +48,6 @@ trait SelectCardTrait
   }
 
   public function stSelect() {
-    var_dump('stSelect() started');
     $atom = Stack::top();
     $player = Players::get($atom['pId']);
 
@@ -63,6 +62,5 @@ trait SelectCardTrait
         Stack::finishState();
       }
     }
-    var_dump('stSelect() finished');
   }
 }

--- a/modules/php/States/SelectCardTrait.php
+++ b/modules/php/States/SelectCardTrait.php
@@ -11,7 +11,7 @@ trait SelectCardTrait
 {
   public function argSelect()
   {
-    $args = Globals::getStackCtx();
+    $args = Stack::getCtx();
 
     $selection = Cards::getSelection()->toArray();
     if (empty($selection)) {
@@ -37,16 +37,18 @@ trait SelectCardTrait
 
   public function actSelect($ids)
   {
-    $stackCtx = Globals::getStackCtx();
+    $stackCtx = Stack::getCtx();
     $playerId = $stackCtx['pId'];
     if ($stackCtx['toResolveFlipped']) {
       Cards::move($ids, LOCATION_FLIPPED);
       Cards::moveAllInLocation(LOCATION_SELECTION, DISCARD);
     }
-    self::reactAux(Players::get($playerId), $ids);
+    Players::get($playerId)->react($ids);
+    Stack::finishState();
   }
 
   public function stSelect() {
+    var_dump('stSelect() started');
     $atom = Stack::top();
     $player = Players::get($atom['pId']);
 
@@ -57,8 +59,10 @@ trait SelectCardTrait
       }, Cards::getSelection()->toArray());
       $typesAmount = count(array_unique($cardTypes));
       if ($typesAmount == 1) {
-        self::reactAux($player, $cards->first()->getId());
+        $player->react($cards->first()->getId());
+        Stack::finishState();
       }
     }
+    var_dump('stSelect() finished');
   }
 }

--- a/modules/php/States/TriggerAbilityTrait.php
+++ b/modules/php/States/TriggerAbilityTrait.php
@@ -12,9 +12,9 @@ trait TriggerAbilityTrait
    */
   public function stTriggerAbility()
   {
-    $atom = Stack::shift();
+    $atom = Stack::top();
     $player = Players::get($atom['pId']);
     $player->useAbility($atom);
-    Stack::resolve();
+    Stack::finishState();
   }
 }


### PR DESCRIPTION
The main ideas behind refaactoring:
- Stack is the only place we work with atoms. Adding, deleting, editing - everything happens inside Stack class
- No more Stack::shift()!
- All atoms have same lifecycle: it starts in stSomething(), does everything what this specific atom does and then, in the very end of stSomething() or actSomething() if this is a user action it calls Stack::finishState(). No other classes apart from st...() and act...() should call Stack::finishState().
- Stack::finishState() by default removes context atom even it's in the middle of a Stack. But we can "suspend" any atom to prevent this to do. Mostly used for ST_PLAY_CARD and ST_REACT when you need to play 2 Missed, Barrel, Jourdonnais and you keep returning to ST_REACT