### PR TITLE
[56936] fix for incorrect turn order when Suzy Lafayette duels

### DIFF
--- a/modules/php/Core/Stack.php
+++ b/modules/php/Core/Stack.php
@@ -27,7 +27,7 @@ class Stack
     foreach ($flow as $state) {
       if (is_int($state)) {
         $options = [
-          'pId' => ($state == ST_END_OF_TURN || $state == ST_GAME_END) ? null : Globals::getPIdTurn(),
+          'pId' => $state == ST_GAME_END ? null : Globals::getPIdTurn(),
         ];
         if ($state == ST_PLAY_CARD) {
           $options['suspended'] = true;
@@ -131,7 +131,7 @@ class Stack
     self::insertAfter($atom, $i);
   }
 
-  public function isItLastElimination()
+  public static function isItLastElimination()
   {
     $stack = Stack::get();
     return count($stack) <= 1 || $stack[1]['state'] != ST_PRE_ELIMINATE_CHECK;
@@ -147,7 +147,7 @@ class Stack
   {
     $stack = Stack::get();
     Utils::filter($stack, function ($atom) use ($pId) {
-      return !isset($atom['pId']) || $atom['pId'] != $pId || $atom['uid'] == Stack::getCtx()['uid'];
+      return !isset($atom['pId']) || $atom['pId'] != $pId || $atom['uid'] == Stack::getCtx()['uid'] || $atom['state'] === ST_END_OF_TURN;
     });
     Stack::set($stack);
   }

--- a/modules/php/States/TurnTrait.php
+++ b/modules/php/States/TurnTrait.php
@@ -6,6 +6,7 @@ use BANG\Core\Log;
 use BANG\Core\Globals;
 use BANG\Core\Notifications;
 use BANG\Core\Stack;
+use bang;
 
 trait TurnTrait
 {
@@ -101,6 +102,10 @@ trait TurnTrait
    */
   public function stEndOfTurn()
   {
+    // To make sure we will switch to next player after this one.
+    // We had a bug when Suzy Lafayette was drawing a card and "capturing" active player status while real active player was dying
+    $ctx = Stack::getCtx();
+    bang::get()->gamestate->changeActivePlayer($ctx['pId']);
     $this->gamestate->nextState('next');
   }
 }


### PR DESCRIPTION
Was happening because Suzy Lafayette was winning the duel using last Bang. After the death of her opponent next player AFTER HER was starting a turn. That was because her ST_TRIGGER_ABILITY atom was the second to last in Stack hence she received "active player" status before switching turn