### PR TITLE
[feature] introduced Rules concept 

### DIFF
--- a/bang.game.php
+++ b/bang.game.php
@@ -53,6 +53,7 @@ class bang extends Table
   use BANG\States\EndOfGameTrait;
   use BANG\States\TriggerAbilityTrait;
   use BANG\States\PreferencesTrait;
+  use BANG\States\PhaseOneTrait;
 
   public static $instance = null;
   public function __construct()

--- a/dbmodel.sql
+++ b/dbmodel.sql
@@ -39,7 +39,15 @@ CREATE TABLE IF NOT EXISTS `card` (
   PRIMARY KEY (`card_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-
+-- Please make sure all fields correspond with constants for rules from constants.inc.php
+CREATE TABLE IF NOT EXISTS `rules` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `player_id` int(11) NOT NULL,
+    `phase_one_amount_to_draw_beginning` int(1) NOT NULL,
+    `phase_one_player_special_draw` int(1) NOT NULL,
+    `phase_one_amount_to_draw_end` int(1) NOT NULL,
+    PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `global_variables` (
   `name` varchar(255) NOT NULL,

--- a/dbmodel.sql
+++ b/dbmodel.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS `rules` (
     `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `player_id` int(11) NOT NULL,
     `phase_one_amount_to_draw_beginning` int(1) NOT NULL,
-    `phase_one_player_special_draw` int(1) NOT NULL,
+    `phase_one_player_ability_draw` int(1) NOT NULL,
     `phase_one_amount_to_draw_end` int(1) NOT NULL,
     PRIMARY KEY (`id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/modules/constants.inc.php
+++ b/modules/constants.inc.php
@@ -13,7 +13,8 @@ define('ST_REACT', 8);
 define('ST_REACT_BEER', 9);
 define('ST_END_OF_TURN', 11);
 define('ST_DISCARD_EXCESS', 12);
-define('ST_DRAW_CARDS', 13);
+define('ST_DRAW_CARDS', 13); // Deprecated, used for backward compatibility
+define('ST_PHASE_ONE_SETUP', 13);
 define('ST_SELECT_CARD', 15);
 define('ST_ACTIVE_DRAW_CARD', 17);
 define('ST_ELIMINATE', 16);
@@ -23,6 +24,7 @@ define('ST_TRIGGER_ABILITY', 20);
 define('ST_PRE_ELIMINATE', 21);
 define('ST_VICE_PENALTY', 22);
 define('ST_PRE_ELIMINATE_DISCARD', 23);
+define('ST_PHASE_ONE_DRAW_CARDS', 24);
 define('ST_PRE_GAME_END', 98);
 define('ST_GAME_END', 99);
 
@@ -206,3 +208,10 @@ define('LOCATION_DISCARD', 'discard');
  */
 define('GENERAL_STORE_MANUAL_CHOOSE', 0);
 define('GENERAL_STORE_AUTO_PICK', 1);
+
+/*
+ * Constants for rules
+ */
+define('RULE_PHASE_ONE_CARDS_DRAW_BEGINNING', 'phase_one_amount_to_draw_beginning');
+define('RULE_PHASE_ONE_PLAYER_ABILITY_DRAW', 'phase_one_player_ability_draw');
+define('RULE_PHASE_ONE_CARDS_DRAW_END', 'phase_one_amount_to_draw_end');

--- a/modules/php/Characters/BlackJack.php
+++ b/modules/php/Characters/BlackJack.php
@@ -1,8 +1,8 @@
 <?php
 namespace BANG\Characters;
 use BANG\Core\Notifications;
-use BANG\Helpers\Utils;
 use BANG\Managers\Cards;
+use BANG\Managers\Rules;
 
 class BlackJack extends \BANG\Models\Player
 {
@@ -19,20 +19,16 @@ class BlackJack extends \BANG\Models\Player
     parent::__construct($row);
   }
 
-  public function drawCardsPhaseOne()
+  public function drawCardsAbility()
   {
-    // Draw one card not visible
-    $cards = Cards::deal($this->id, 1);
-    Notifications::drawCards($this, $cards);
-    // Then draw one visible
+    // Draw one visible
     $cards = Cards::deal($this->id, 1);
     Notifications::drawCards($this, $cards, true);
 
     // If heart or diamond => draw again a private one
     $card = $cards->first();
     if (in_array($card->getCopyColor(), ['H', 'D'])) {
-      $cards = Cards::deal($this->id, 1);
-      Notifications::drawCards($this, $cards);
+      Rules::amendRules([RULE_PHASE_ONE_CARDS_DRAW_END => 1]);
     }
     $this->onChangeHand();
   }

--- a/modules/php/Characters/JesseJones.php
+++ b/modules/php/Characters/JesseJones.php
@@ -2,9 +2,9 @@
 namespace BANG\Characters;
 use BANG\Core\Notifications;
 use BANG\Core\Stack;
-use BANG\Helpers\Utils;
 use BANG\Managers\Cards;
 use BANG\Managers\Players;
+use BANG\Managers\Rules;
 
 class JesseJones extends \BANG\Models\Player
 {
@@ -21,7 +21,7 @@ class JesseJones extends \BANG\Models\Player
     parent::__construct($row);
   }
 
-  public function drawCardsPhaseOne()
+  public function drawCardsAbility()
   {
     // TODO : auto skip if argDrawCard only has 'deck' inside
     Stack::insertOnTop(Stack::newAtom(ST_ACTIVE_DRAW_CARD, [
@@ -43,7 +43,7 @@ class JesseJones extends \BANG\Models\Player
   public function useAbility($args)
   {
     if ($args['selected'] == LOCATION_DECK) {
-      $this->drawCards(2);
+      $cardsToDraw = 2;
     } else {
       // TODO : add sanity check
 
@@ -55,7 +55,8 @@ class JesseJones extends \BANG\Models\Player
       $victim->onChangeHand();
 
       // Deal the second one
-      $this->drawCards(1);
+      $cardsToDraw = 1;
     }
+    Rules::amendRules([RULE_PHASE_ONE_CARDS_DRAW_END => $cardsToDraw]);
   }
 }

--- a/modules/php/Characters/KitCarlson.php
+++ b/modules/php/Characters/KitCarlson.php
@@ -20,9 +20,9 @@ class KitCarlson extends \BANG\Models\Player
     parent::__construct($row);
   }
 
-  public function drawCardsPhaseOne()
+  public function drawCardsAbility()
   {
-    $cards = Cards::drawForLocation(LOCATION_SELECTION, 3);
+    Cards::drawForLocation(LOCATION_SELECTION, 3);
     $this->prepareSelection($this, [$this->id], true, 2);
   }
 

--- a/modules/php/Characters/PedroRamirez.php
+++ b/modules/php/Characters/PedroRamirez.php
@@ -2,8 +2,8 @@
 namespace BANG\Characters;
 use BANG\Core\Notifications;
 use BANG\Core\Stack;
-use BANG\Helpers\Utils;
 use BANG\Managers\Cards;
+use BANG\Managers\Rules;
 
 class PedroRamirez extends \BANG\Models\Player
 {
@@ -20,10 +20,10 @@ class PedroRamirez extends \BANG\Models\Player
     parent::__construct($row);
   }
 
-  public function drawCardsPhaseOne()
+  public function drawCardsAbility()
   {
     if (is_null(Cards::getLastDiscarded())) {
-      parent::drawCardsPhaseOne();
+      Rules::amendRules([RULE_PHASE_ONE_CARDS_DRAW_END => 2]);
     } else {
       Stack::insertOnTop(Stack::newAtom(ST_ACTIVE_DRAW_CARD, [
         'pId' => $this->id,
@@ -40,13 +40,14 @@ class PedroRamirez extends \BANG\Models\Player
   public function useAbility($args)
   {
     if ($args['selected'] == LOCATION_DECK) {
-      $this->drawCards(2);
+      $cardsToDraw = 2;
     } else {
       // Draw the first one from discard
       $cards = Cards::dealFromDiscard($this->id, 1);
       Notifications::drawCardFromDiscard($this, $cards);
       // The second one from deck
-      $this->drawCards(1);
+      $cardsToDraw = 1;
     }
+    Rules::amendRules([RULE_PHASE_ONE_CARDS_DRAW_END => $cardsToDraw]);
   }
 }

--- a/modules/php/Helpers/QueryBuilder.php
+++ b/modules/php/Helpers/QueryBuilder.php
@@ -130,14 +130,13 @@ class QueryBuilder extends \APP_DbObject
    */
   public function select($columns)
   {
+    if (!is_array($columns)) {
+      $columns = [$columns];
+    }
     $cols = ["{$this->primary} AS `result_associative_index`"];
 
-    if (!is_array($columns)) {
-      $cols = [$columns];
-    } else {
-      foreach ($columns as $alias => $col) {
-        $cols[] = is_numeric($alias) ? "$col" : "$col AS `$alias`";
-      }
+    foreach ($columns as $alias => $col) {
+      $cols[] = is_numeric($alias) ? "$col" : "$col AS `$alias`";
     }
 
     $this->columns = implode(' , ', $cols);

--- a/modules/php/Managers/Players.php
+++ b/modules/php/Managers/Players.php
@@ -117,22 +117,22 @@ class Players extends \BANG\Helpers\DB_Manager
   /******************************
    ******* GENERIC GETTERS *******
    ******************************/
-  public function getActiveId()
+  public static function getActiveId()
   {
     return self::getGame()->getActivePlayerId();
   }
 
-  public function getCurrentId()
+  public static function getCurrentId()
   {
     return self::getGame()->getCurrentPId();
   }
 
-  public function getAll()
+  public static function getAll()
   {
     return self::DB()->get(false);
   }
 
-  public function get($pId = null)
+  public static function get($pId = null)
   {
     $pId = $pId ?: self::getActiveId();
     return self::DB()
@@ -140,12 +140,12 @@ class Players extends \BANG\Helpers\DB_Manager
       ->getSingle();
   }
 
-  public function getActive()
+  public static function getActive()
   {
     return self::get();
   }
 
-  public function getCurrent()
+  public static function getCurrent()
   {
     return self::get(self::getCurrentId());
   }
@@ -155,19 +155,19 @@ class Players extends \BANG\Helpers\DB_Manager
     return self::get(Globals::getPIdTurn());
   }
 
-  public function count()
+  public static function count()
   {
     return self::DB()->count();
   }
 
-  public function getUiData($pId)
+  public static function getUiData($pId)
   {
     return self::getAll()->map(function ($player) use ($pId) {
       return $player->getUiData($pId);
     });
   }
 
-  public function getDistances()
+  public static function getDistances()
   {
     return self::getLivingPlayers()->map(function ($player) {
       return $player->getDistances();
@@ -211,13 +211,13 @@ class Players extends \BANG\Helpers\DB_Manager
     return $result;
   }
 
-  public function getCharacter($cId, $row = null)
+  public static function getCharacter($cId, $row = null)
   {
     $className = 'BANG\Characters\\' . self::$classes[$cId];
     return new $className($row);
   }
 
-  public function getCharacterBullets($cId)
+  public static function getCharacterBullets($cId)
   {
     $char = self::getCharacter($cId, null);
     return $char->getBullets();

--- a/modules/php/Managers/Rules.php
+++ b/modules/php/Managers/Rules.php
@@ -1,0 +1,77 @@
+<?php
+namespace BANG\Managers;
+use BANG\Helpers\DB_Manager;
+
+/*
+ * Rules: all turn rules and all changes to them according to player role and event and all other factors
+ */
+class Rules extends DB_Manager
+{
+  protected static $table = 'rules';
+  protected static $primary = 'id';
+
+  /*
+   * get: common method for getting a specific rule from the list
+   */
+  private static function getRule($rule)
+  {
+    return self::DB()
+      ->orderBy(self::$primary, 'DESC')
+      ->select($rule)
+      ->getSingle()[$rule];
+  }
+
+  private static function get()
+  {
+    $row = self::DB()
+      ->orderBy(self::$primary, 'DESC')
+      ->getSingle();
+    unset($row['id']);
+    return $row;
+  }
+
+  public static function amendRules($newRules)
+  {
+    $rules = self::get();
+    $rules = array_merge($rules, $newRules);
+    self::DB()->insert($rules);
+  }
+
+  public static function setNewTurnRules($player)
+  {
+    $playerCharacter = $player->getCharacter();
+    switch ($playerCharacter) {
+      case BLACK_JACK:
+        $rules = [1, true, 0];
+        break;
+      case JESSE_JONES:
+      case PEDRO_RAMIREZ:
+        $rules = [0, true, 1];
+        break;
+      case KIT_CARLSON:
+        $rules = [0, true, 0];
+        break;
+      default:
+        $rules = [2, false, 0];
+    }
+    self::DB()->insert([
+      'player_id' => $player->getId(),
+      RULE_PHASE_ONE_CARDS_DRAW_BEGINNING => $rules[0],
+      RULE_PHASE_ONE_PLAYER_ABILITY_DRAW => $rules[1],
+      RULE_PHASE_ONE_CARDS_DRAW_END => $rules[2],
+    ]);
+  }
+
+  public static function getPhaseOneCardsAmount($rule)
+  {
+    if (!in_array($rule, [RULE_PHASE_ONE_CARDS_DRAW_BEGINNING, RULE_PHASE_ONE_CARDS_DRAW_END])) {
+      throw new \BgaVisibleSystemException("getPhaseOneCardsAmount - Unexpected rule: $rule");
+    }
+    return (int) self::getRule($rule);
+  }
+
+  public static function isPhaseOnePlayerSpecialDraw()
+  {
+    return self::getRule(RULE_PHASE_ONE_PLAYER_ABILITY_DRAW) === '1';
+  }
+}

--- a/modules/php/Models/Player.php
+++ b/modules/php/Models/Player.php
@@ -186,9 +186,11 @@ class Player extends \BANG\Helpers\DB_Manager
    */
   public function drawCards($amount)
   {
-    $cards = Cards::deal($this->id, $amount);
-    Notifications::drawCards($this, $cards);
-    $this->onChangeHand();
+    if ($amount > 0) {
+      $cards = Cards::deal($this->id, $amount);
+      Notifications::drawCards($this, $cards);
+      $this->onChangeHand();
+    }
   }
 
   /*
@@ -529,15 +531,6 @@ class Player extends \BANG\Helpers\DB_Manager
    **************** Actions ***************
    ****************************************
    ***************************************/
-
-  /*
-   * Draw cards at phase one of turn
-   *  -> will be overwriten by character abilities that happens at phase 1
-   */
-  public function drawCardsPhaseOne()
-  {
-    $this->drawCards(2);
-  }
 
   /**
    * startOfTurn: is called at the beginning of each turn (before the drawing phase)

--- a/modules/php/States/DrawCardsTrait.php
+++ b/modules/php/States/DrawCardsTrait.php
@@ -1,21 +1,10 @@
 <?php
 namespace BANG\States;
 use BANG\Managers\Players;
-use BANG\Core\Log;
 use BANG\Core\Stack;
 
 trait DrawCardsTrait
 {
-  /*
-   * stDrawCards: called after the beggining of each player turn, if the turn was not skipped or if no character's abilities apply
-   */
-  public function stDrawCards()
-  {
-    $player = Players::getActive();
-    $player->drawCardsPhaseOne();
-    Stack::finishState();
-  }
-
   /************************
    **** drawCard state ****
    ***********************/

--- a/modules/php/States/PhaseOneTrait.php
+++ b/modules/php/States/PhaseOneTrait.php
@@ -1,0 +1,48 @@
+<?php
+namespace BANG\States;
+use BANG\Managers\Players;
+use BANG\Core\Stack;
+use BANG\Managers\Rules;
+
+trait PhaseOneTrait
+{
+  /*
+   * stPhaseOneSetup: called on the beginning of each player turn, if the turn was not skipped, to add 3 phase on sub-phases
+   */
+  public function stPhaseOneSetup()
+  {
+    $player = Players::getActive();
+
+    Stack::insertOnTop(self::phaseOneAtom($player, RULE_PHASE_ONE_CARDS_DRAW_END));
+    if (Rules::isPhaseOnePlayerSpecialDraw()) {
+      Stack::insertOnTop(self::phaseOneAtom($player, RULE_PHASE_ONE_PLAYER_ABILITY_DRAW));
+    }
+    Stack::insertOnTop(self::phaseOneAtom($player, RULE_PHASE_ONE_CARDS_DRAW_BEGINNING));
+    Stack::finishState();
+  }
+
+  private function phaseOneAtom($player, $drawCards)
+  {
+    return Stack::newAtom(ST_PHASE_ONE_DRAW_CARDS, [
+      'pId' => $player->getId(),
+      'subPhase' => $drawCards
+    ]);
+  }
+
+  /*
+ * stPhaseOneSetup: called on the beginning of each player turn, if the turn was not skipped, to add 3 phase on sub-phases
+ */
+  public function stPhaseOneDrawCards()
+  {
+    $ctx = Stack::getCtx();
+    $player = Players::get($ctx['pId']);
+    $subPhase = $ctx['subPhase'];
+    if ($subPhase === RULE_PHASE_ONE_PLAYER_ABILITY_DRAW) {
+      $player->drawCardsAbility();
+    } else {
+      $amount = Rules::getPhaseOneCardsAmount($subPhase);
+      $player->drawCards($amount);
+    }
+    Stack::finishState();
+  }
+}

--- a/modules/php/States/TurnTrait.php
+++ b/modules/php/States/TurnTrait.php
@@ -6,6 +6,7 @@ use BANG\Core\Log;
 use BANG\Core\Globals;
 use BANG\Core\Notifications;
 use BANG\Core\Stack;
+use BANG\Managers\Rules;
 use bang;
 
 trait TurnTrait
@@ -39,8 +40,9 @@ trait TurnTrait
   {
     Log::startTurn();
     $player = Players::getActive();
+    Rules::setNewTurnRules($player);
     Globals::setPIdTurn($player->getId());
-    Stack::setup([ST_DRAW_CARDS, ST_PLAY_CARD, ST_DISCARD_EXCESS, ST_END_OF_TURN]);
+    Stack::setup([ST_PHASE_ONE_SETUP, ST_PLAY_CARD, ST_DISCARD_EXCESS, ST_END_OF_TURN]);
     $player->startOfTurn();
     Stack::finishState();
   }

--- a/states.inc.php
+++ b/states.inc.php
@@ -21,7 +21,6 @@ $machinestates = [
    */
   ST_START_OF_TURN => [
     'name' => 'startOfTurn',
-    'description' => '',
     'type' => 'game',
     'action' => 'stStartOfTurn',
     'transitions' => [
@@ -34,29 +33,31 @@ $machinestates = [
    */
   ST_RESOLVE_STACK => [
     'name' => 'resolveStack',
-    'description' => '',
     'type' => 'game',
     'action' => 'stResolveStack',
     'transitions' => [],
   ],
 
-  ST_DRAW_CARDS => [
-    'name' => 'drawCards',
-    'description' => '',
+  ST_PHASE_ONE_SETUP => [
+    'name' => 'phaseOneSetup',
     'type' => 'game',
-    'action' => 'stDrawCards',
+    'action' => 'stPhaseOneSetup',
+  ],
+
+  ST_PHASE_ONE_DRAW_CARDS => [
+    'name' => 'phaseOneDrawCards',
+    'type' => 'game',
+    'action' => 'stPhaseOneDrawCards',
   ],
 
   ST_FLIP_CARD => [
     'name' => 'flipCard',
-    'description' => '',
     'type' => 'game',
     'action' => 'stFlipCard',
   ],
 
   ST_RESOLVE_FLIPPED => [
     'name' => 'resolveFlipped',
-    'description' => '',
     'type' => 'game',
     'action' => 'stResolveFlipped',
   ],
@@ -139,7 +140,6 @@ $machinestates = [
 
   ST_ELIMINATE => [
     'name' => 'eliminate',
-    'description' => '',
     'type' => 'game',
     'action' => 'stEliminate',
     'updateGameProgression' => true,
@@ -158,14 +158,12 @@ $machinestates = [
 
   ST_TRIGGER_ABILITY => [
     'name' => 'triggerAbility',
-    'description' => '',
     'type' => 'game',
     'action' => 'stTriggerAbility',
   ],
 
   ST_END_OF_TURN => [
     'name' => 'endOfTurn',
-    'description' => '',
     'type' => 'game',
     'action' => 'stEndOfTurn',
     'transitions' => [
@@ -175,7 +173,6 @@ $machinestates = [
 
   ST_NEXT_PLAYER => [
     'name' => 'nextPlayer',
-    'description' => '',
     'type' => 'game',
     'action' => 'stNextPlayer',
     'transitions' => [


### PR DESCRIPTION
I'd like to introduce a new Rules Manager and a new DB table. Why:
1. Expansions make the game logic be multiplied in complexity. The example shown in the code is the following: we have 4 characters which operate with either first or second card of phase 1. In the first expansion we will have 2 events changing rules of phase 1 to "draw 1 card in phase 1" and "draw 3 cards in phase one". Just these 2 cards will make the old logic undebuggable and a nightmare to implement
2. Some situations are resolved using hacks, saving some state from one atom to another. We can store this in Rules. E.g. recent Suzy Lafayette fix (https://boardgamearena.com/bug?id=56936) requires us to remember who's turn was it. Another example: the existence of states PRE_ELIMINATE_DISCARD, PRE_ELIMINATE, ELIMINATE - that doesn't look good :) We would end up with PRE_PRE_PRE_ELIMINATE :D
3. Rules changes are easy to track with the implementation from this PR. Each change is written to DB as a separate row. In case of error we could dump last X changes somewhere and see what happened

This is just a proof of concept, shouldn't be merged at the moment!