### PR TITLE
[60506] Sid Ketchum can use both beers + his ability

### DIFF
--- a/bang.js
+++ b/bang.js
@@ -277,17 +277,20 @@ define([
       onClickCardUseAbility: function (card) {
         this.toggleCard(card);
 
+        const buttonVisible = $('buttonConfirmUseAbility');
         if (this._selectedCards.length < this._amount) {
-          if ($('buttonConfirmUseAbility')) dojo.destroy('buttonConfirmUseAbility');
+          if (buttonVisible) dojo.destroy('buttonConfirmUseAbility');
         } else {
-          this.addActionButton(
-            'buttonConfirmUseAbility',
-            _('Confirm'),
-            'onClickConfirmUseAbility',
-            null,
-            false,
-            'blue',
-          );
+          if (!buttonVisible) {
+            this.addActionButton(
+                'buttonConfirmUseAbility',
+                _('Confirm'),
+                'onClickConfirmUseAbility',
+                null,
+                false,
+                'blue',
+            );
+          }
         }
       },
 

--- a/modules/js/States/ReactTrait.js
+++ b/modules/js/States/ReactTrait.js
@@ -117,11 +117,11 @@ define(['dojo', 'dojo/_base/declare'], (dojo, declare) => {
       if (!this.toggleCard(card)) return;
 
       this.clearActionButtons();
-      if (this._selectedCards.length < this._amount) {
-        if (this._selectedCards.length == 0) {
-          this.addDangerActionButton('buttonConfirmPass', _('Pass and die'), () => this.onClickPass());
-        } else {
-          this.addDangerActionButton('buttonConfirmReact', _('Play and die'), () => this.onClickConfirmReact(true));
+      if (this._selectedCards.length === 0) {
+        let SID_KETCHUM = 9;
+        this.addDangerActionButton('buttonConfirmPass', _('Pass and die'), () => this.onClickPass());
+        if (this.gamedatas.players[this.player_id].characterId === SID_KETCHUM) {
+          this.makeCharacterAbilityUsable(SID_KETCHUM);
         }
       } else {
         this.addPrimaryActionButton('buttonConfirmReact', _('Confirm'), () => this.onClickConfirmReact(true));

--- a/modules/php/Characters/SidKetchum.php
+++ b/modules/php/Characters/SidKetchum.php
@@ -47,6 +47,6 @@ class SidKetchum extends \BANG\Models\Player
     }
     Notifications::discardedCards($this, $cards, false, $cards->getIds());
     $this->gainLife();
-    $this->eliminateIfOutOfHp();
+    $this->addRevivalAtomOrEliminate();
   }
 }

--- a/modules/php/Models/Player.php
+++ b/modules/php/Models/Player.php
@@ -279,6 +279,14 @@ class Player extends \BANG\Helpers\DB_Manager
     $this->hp -= $amount;
     $this->save();
     Notifications::lostLife($this, $amount);
+    $this->addRevivalAtomOrEliminate();
+  }
+
+  /**
+   * used when player drinks a beer or Sid Ketchum uses his ability to gain life discarding 2 cards
+   */
+  public function addRevivalAtomOrEliminate()
+  {
     if ($this->hp <= 0) {
       $ctx = Stack::getCtx();
       $isDuel = Players::getLivingPlayers()->count() <= 2;
@@ -296,24 +304,6 @@ class Player extends \BANG\Helpers\DB_Manager
         'src' => $ctx['src'] ?? null,
         'attacker' => $ctx['attacker'] ?? null,
         'pId' => $this->id,
-      ]);
-      Stack::insertAfterCardResolution($atom);
-    }
-  }
-
-  /**
-   * used when player drinks a beer or Sid Ketchum uses his ability to gain life discarding 2 cards
-   */
-  public function eliminateIfOutOfHp()
-  {
-    // If it's not enough, add a ELIMINATE node
-    if ($this->getHp() <= 0) {
-      $ctx = Stack::getCtx();
-      $atom = Stack::newAtom(ST_PRE_ELIMINATE_DISCARD, [
-        'type' => 'eliminateDiscard',
-        'src' => $ctx['src'],
-        'attacker' => $ctx['attacker'],
-        'pId' => $this->getId(),
       ]);
       Stack::insertAfterCardResolution($atom);
     }

--- a/modules/php/States/EndOfLifeTrait.php
+++ b/modules/php/States/EndOfLifeTrait.php
@@ -34,7 +34,7 @@ trait EndOfLifeTrait
         $player->playCard($card, []);
       }
     }
-    $player->eliminateIfOutOfHp();
+    $player->addRevivalAtomOrEliminate();
   }
 
   public function argDiscardEliminate()


### PR DESCRIPTION
- fixed "Confirm" button appearing infinitely when clicking on non-selectable card
- fixed "Use ability" button for Sid Ketchum not appearing after clicking twice on Beer while reviving
- while reviving after Dynamite Sid Ketchum can use his ability infinite amount of times
- while reviving after Dynamite Sid Ketchum can use Beer and then his ability or vice versa
- while reviving after Dynamite any player can use one beer after another, not 2 or 3 together