### PR TITLE
#46035 make setWinners consider kill order

### DIFF
--- a/modules/php/Models/Player.php
+++ b/modules/php/Models/Player.php
@@ -702,7 +702,7 @@ class Player extends \BANG\Helpers\DB_Manager
     $this->save();
 
     // Check if game should end
-    if (Stack::isItLastElimination() && Players::isEndOfGame()) {
+    if ($this->role == SHERIFF || (Stack::isItLastElimination() && Players::isEndOfGame())) {
       bang::get()->setWinners();
     }
 

--- a/modules/php/States/EndOfGameTrait.php
+++ b/modules/php/States/EndOfGameTrait.php
@@ -13,7 +13,12 @@ trait EndOfGameTrait
   public function setWinners()
   {
     $living = Players::getLivingPlayers();
-    if (Players::countRoles([SHERIFF]) == 0) {
+    if (Players::countRoles([OUTLAW, RENEGADE]) == 0) {
+      Players::setWinners([SHERIFF, DEPUTY]);
+      Notifications::tell(
+        clienttranslate('All the renegades and outlaws have been killed and thus Sheriff and Deputies win this game.')
+      );
+    } elseif (Players::countRoles([SHERIFF]) == 0) {
 
       // That not's really possible, is it ?
       if (count($living) == 0) {
@@ -25,13 +30,6 @@ trait EndOfGameTrait
         Players::setWinners([OUTLAW]);
         Notifications::tell(clienttranslate('The sheriff has been killed and thus the outlaws win this game.'));
       }
-    }
-
-    if (Players::countRoles([OUTLAW, RENEGADE]) == 0) {
-      Players::setWinners([SHERIFF, DEPUTY]);
-      Notifications::tell(
-        clienttranslate('All the renegades and outlaws have been killed and thus Sheriff and Deputies win this game.')
-      );
     }
 
     if(count($living) == 1){


### PR DESCRIPTION
When multiple players get killed from one same action (ie playing Indians or Gatling), the kill order should matter to determine the winner.
I've made the game end immediately when the sheriff is killed so that if there are renegades or outlaws still alive, they win, even if they will get killed later.
This should fix 61477 too.


