### PR TITLE
[60307] fix Sid Ketchum's ability discard order

### DIFF
--- a/modules/php/Characters/SidKetchum.php
+++ b/modules/php/Characters/SidKetchum.php
@@ -42,10 +42,8 @@ class SidKetchum extends \BANG\Models\Player
     );
 
     $cards = Cards::getMany($args);
-    foreach ($cards as $card) {
-      $card->discard();
-    }
-    Notifications::discardedCards($this, $cards, false, $cards->getIds());
+    Cards::discardMany($args);
+    Notifications::discardedCards($this, $cards, false, $args);
     $this->gainLife();
     $this->addRevivalAtomOrEliminate();
   }


### PR DESCRIPTION
`$args` contains selected card ids in the chosen order, when we get `$cards` from the db using `getMany()` they come ordered by card id, and the same applies for notifications.