### PR TITLE
fix ElGringo's ability after being hit by Suzy's last card

### DIFF
--- a/modules/php/Characters/ElGringo.php
+++ b/modules/php/Characters/ElGringo.php
@@ -39,8 +39,15 @@ class ElGringo extends \BANG\Models\Player
     $attacker = Players::getCurrentTurn();
     for ($i = 0; $i < $ctx['amount']; $i++) {
       $card = $attacker->getRandomCardInHand(false);
-      if ($card === null) {
-        return; // No more cards in hand of attacker
+      if ($card === null) { // No more cards in hand of attacker
+        if ($attacker->getCharacter() == SUZY_LAFAYETTE) {
+          // if attacker Suzy has no cards we need to wait until she draws a new one
+          Stack::insertAfter(Stack::newAtom(ST_TRIGGER_ABILITY, [
+            'pId' => $this->id,
+            'amount' => $ctx['amount'],
+          ]), 2);
+        }
+        return;
       }
       Cards::move($card->getId(), LOCATION_HAND, $this->getId());
       Notifications::stoleCard($this, $attacker, $card, false);

--- a/modules/php/Managers/Players.php
+++ b/modules/php/Managers/Players.php
@@ -132,6 +132,10 @@ class Players extends \BANG\Helpers\DB_Manager
     return self::DB()->get(false);
   }
 
+  /**
+   * @param $pId
+   * @return Player
+   */
   public function get($pId = null)
   {
     $pId = $pId ?: self::getActiveId();


### PR DESCRIPTION
When Suzy hits ElGringo using her last card her ability activates first, drawing a card from the deck. Then ElGringo steals that card and Suzy draws another one. [Tournament rules](https://www.dvgiochi.com/bang_champ/MaterialeCampionato/BANG%21%20Campionato%20nazionale_Regolamento-daTorneo.pdf)