### PR TITLE
#49 selection saves card order

### DIFF
--- a/modules/php/Helpers/Pieces.php
+++ b/modules/php/Helpers/Pieces.php
@@ -380,7 +380,7 @@ class Pieces extends DB_Manager
    * Pick the first "$nbr" pieces on top of specified deck and place it in target location
    * Return pieces infos or void array if no card in the specified location
    */
-  public static function pickForLocation($nbr, $fromLocation, $toLocation, $state = 0, $deckReform = true)
+  public static function pickForLocation($nbr, $fromLocation, $toLocation, $state = null, $deckReform = true)
   {
     self::checkLocation($fromLocation);
     self::checkLocation($toLocation);

--- a/modules/php/Managers/Cards.php
+++ b/modules/php/Managers/Cards.php
@@ -180,7 +180,7 @@ class Cards extends \BANG\Helpers\Pieces
 
   public static function getSelection()
   {
-    return self::getInLocation(LOCATION_SELECTION);
+    return self::getInLocation(LOCATION_SELECTION, null, 'state');
   }
 
   public static function putOnDeck($cId)


### PR DESCRIPTION
When we draw cards for selection, we don't overwrite the state and we use it to sort the cards.